### PR TITLE
feat: Add ability to list pending invoices

### DIFF
--- a/modules/Fina/database/factories/APInvoiceHeaderFactory.php
+++ b/modules/Fina/database/factories/APInvoiceHeaderFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Modules\Fina\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Modules\Fina\FI\AP\Domain\Entities\APInvoiceHeader;
+
+class APInvoiceHeaderFactory extends Factory
+{
+    protected $model = APInvoiceHeader::class;
+
+    public function definition()
+    {
+        return [
+            'gl_document_header_id' => $this->faker->numberBetween(1, 100),
+            'vendor_id' => $this->faker->numberBetween(1, 100),
+            'invoice_number_vendor' => $this->faker->uuid,
+            'invoice_date' => $this->faker->date(),
+            'due_date' => $this->faker->date(),
+            'gross_amount' => $this->faker->randomFloat(2, 100, 1000),
+            'net_amount' => $this->faker->randomFloat(2, 80, 800),
+            'tax_amount' => $this->faker->randomFloat(2, 20, 200),
+            'payment_status' => $this->faker->randomElement(['Open', 'Partially Paid', 'Paid']),
+            'po_number' => $this->faker->optional()->ean13,
+        ];
+    }
+}

--- a/modules/Fina/routes/api.php
+++ b/modules/Fina/routes/api.php
@@ -15,6 +15,7 @@ Route::prefix('fina')->group(function () {
     Route::prefix('ap')->group(function () {
         Route::post('invoices', [APInvoiceController::class, 'store']);
         Route::get('invoices/{id}', [APInvoiceController::class, 'show']);
+        Route::get('invoices', [APInvoiceController::class, 'index']);
     });
 
     Route::prefix('ar')->group(function () {

--- a/modules/Fina/src/Core/Providers/FinaServiceProvider.php
+++ b/modules/Fina/src/Core/Providers/FinaServiceProvider.php
@@ -28,6 +28,7 @@ class FinaServiceProvider extends ServiceProvider
         $this->registerConfig();
         $this->registerViews();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'database/migrations'));
+        $this->loadFactoriesFrom(module_path($this->moduleName, 'database/factories'));
         $this->loadRoutes();
     }
 

--- a/modules/Fina/src/FI/AP/Domain/Repositories/APInvoiceRepositoryInterface.php
+++ b/modules/Fina/src/FI/AP/Domain/Repositories/APInvoiceRepositoryInterface.php
@@ -8,4 +8,5 @@ interface APInvoiceRepositoryInterface
 {
     public function create(array $data): APInvoiceHeader;
     public function find(int $id): ?APInvoiceHeader;
+    public function all(string $status = null);
 }

--- a/modules/Fina/src/FI/AP/Http/Controllers/APInvoiceController.php
+++ b/modules/Fina/src/FI/AP/Http/Controllers/APInvoiceController.php
@@ -35,4 +35,11 @@ class APInvoiceController extends Controller
         }
         return response()->json($invoice);
     }
+
+    public function index(Request $request)
+    {
+        $status = $request->query('status');
+        $invoices = $this->apInvoiceRepository->all($status);
+        return response()->json($invoices);
+    }
 }

--- a/modules/Fina/src/FI/AP/Infrastructure/Persistence/EloquentAPInvoiceRepository.php
+++ b/modules/Fina/src/FI/AP/Infrastructure/Persistence/EloquentAPInvoiceRepository.php
@@ -16,4 +16,15 @@ class EloquentAPInvoiceRepository implements APInvoiceRepositoryInterface
     {
         return APInvoiceHeader::find($id);
     }
+
+    public function all(string $status = null)
+    {
+        $query = APInvoiceHeader::query();
+
+        if ($status === 'pending') {
+            $query->whereIn('payment_status', ['Open', 'Partially Paid']);
+        }
+
+        return $query->get();
+    }
 }

--- a/modules/Fina/tests/Feature/APInvoiceTest.php
+++ b/modules/Fina/tests/Feature/APInvoiceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Modules\Fina\Tests\Feature;
+
+use Modules\Fina\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Fina\FI\AP\Domain\Entities\APInvoiceHeader;
+
+class APInvoiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_list_all_invoices()
+    {
+        APInvoiceHeader::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/fina/ap/invoices');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(3);
+    }
+
+    public function test_can_list_pending_invoices()
+    {
+        APInvoiceHeader::factory()->create(['payment_status' => 'Open']);
+        APInvoiceHeader::factory()->create(['payment_status' => 'Partially Paid']);
+        APInvoiceHeader::factory()->create(['payment_status' => 'Paid']);
+
+        $response = $this->getJson('/api/fina/ap/invoices?status=pending');
+
+        $response->assertStatus(200)
+            ->assertJsonCount(2);
+    }
+}


### PR DESCRIPTION
This commit introduces the ability to list all invoices and filter them by a 'pending' status. The 'pending' status includes invoices that are either 'Open' or 'Partially Paid'.

- Adds an `index` method to `APInvoiceController` to handle listing invoices.
- Adds an `all` method to `APInvoiceRepository` to retrieve invoices with an optional status filter.
- Adds a new route `/api/fina/ap/invoices` to access the new functionality.
- Adds a new test file `APInvoiceTest.php` to verify the new functionality.