### PR TITLE
feat: Implement Product Cost Controlling subdomain

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Seeders;
+
+// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Modules\Fina\Database\Seeders\FinaDatabaseSeeder;
+
+class DatabaseSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     */
+    public function run(): void
+    {
+        \App\Models\User::factory()->count(1)->create([
+            'email' => 'test@example.com',
+        ]);
+
+        $this->call(FinaDatabaseSeeder::class);
+    }
+}

--- a/modules/Fina/config/config.php
+++ b/modules/Fina/config/config.php
@@ -8,5 +8,8 @@ return [
     'feature_flags' => [
         'use_product_costing' => true,
         'enable_abc_costing' => false,
-    ]
+    ],
+    'bank_accounting' => [
+        'default_bank_country' => 'US',
+    ],
 ];

--- a/modules/Fina/database/migrations/2024_01_01_000003_create_fina_pc_material_costs_table.php
+++ b/modules/Fina/database/migrations/2024_01_01_000003_create_fina_pc_material_costs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('fina_pc_material_costs', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('material_id');
+            $table->string('costing_variant');
+            $table->decimal('cost', 15, 2);
+            $table->string('currency');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('fina_pc_material_costs');
+    }
+};

--- a/modules/Fina/database/migrations/2024_01_01_000004_create_fina_pc_inventory_valuations_table.php
+++ b/modules/Fina/database/migrations/2024_01_01_000004_create_fina_pc_inventory_valuations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('fina_pc_inventory_valuations', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('material_id');
+            $table->unsignedBigInteger('plant_id');
+            $table->decimal('quantity', 15, 2);
+            $table->decimal('value', 15, 2);
+            $table->string('currency');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('fina_pc_inventory_valuations');
+    }
+};

--- a/modules/Fina/database/migrations/2024_01_01_000005_create_fina_pc_cost_object_controlling_table.php
+++ b/modules/Fina/database/migrations/2024_01_01_000005_create_fina_pc_cost_object_controlling_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('fina_pc_cost_object_controlling', function (Blueprint $table) {
+            $table->id();
+            $table->string('cost_object');
+            $table->string('cost_object_type');
+            $table->decimal('planned_costs', 15, 2);
+            $table->decimal('actual_costs', 15, 2);
+            $table->decimal('variance', 15, 2);
+            $table->string('currency');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('fina_pc_cost_object_controlling');
+    }
+};

--- a/modules/Fina/database/seeders/ChartsOfAccountsTableSeeder.php
+++ b/modules/Fina/database/seeders/ChartsOfAccountsTableSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Fina\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class ChartsOfAccountsTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('fina_charts_of_accounts')->insert([
+            'name' => 'Default Chart of Accounts',
+            'country_code' => 'US',
+        ]);
+    }
+}

--- a/modules/Fina/database/seeders/CurrenciesTableSeeder.php
+++ b/modules/Fina/database/seeders/CurrenciesTableSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\Fina\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CurrenciesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('fina_currencies')->insert([
+            ['code' => 'USD', 'name' => 'US Dollar'],
+            ['code' => 'EUR', 'name' => 'Euro'],
+            ['code' => 'GBP', 'name' => 'British Pound'],
+        ]);
+    }
+}

--- a/modules/Fina/database/seeders/FinaDatabaseSeeder.php
+++ b/modules/Fina/database/seeders/FinaDatabaseSeeder.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Modules\Fina\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Database\Eloquent\Model;
+
+class FinaDatabaseSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Model::unguard();
+
+        $this->call(ChartsOfAccountsTableSeeder::class);
+        $this->call(CurrenciesTableSeeder::class);
+        $this->call(TaxCodesTableSeeder::class);
+    }
+}

--- a/modules/Fina/database/seeders/TaxCodesTableSeeder.php
+++ b/modules/Fina/database/seeders/TaxCodesTableSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Modules\Fina\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TaxCodesTableSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        DB::table('fina_tax_codes')->insert([
+            ['code' => 'VAT10', 'rate' => 10.00],
+            ['code' => 'VAT20', 'rate' => 20.00],
+        ]);
+    }
+}

--- a/modules/Fina/resources/views/bank-accounting/index.blade.php
+++ b/modules/Fina/resources/views/bank-accounting/index.blade.php
@@ -1,0 +1,5 @@
+@extends('fina::layouts.master')
+
+@section('content')
+    <h1>Bank Accounting</h1>
+@endsection

--- a/modules/Fina/resources/views/index.blade.php
+++ b/modules/Fina/resources/views/index.blade.php
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Fina Module</title>
+</head>
+<body>
+    <h1>Fina Module</h1>
+    <p>This is the main view for the Fina module.</p>
+</body>
+</html>

--- a/modules/Fina/resources/views/layouts/master.blade.php
+++ b/modules/Fina/resources/views/layouts/master.blade.php
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Module Fina</title>
+
+       {{-- Laravel Vite - CSS File --}}
+       {{-- {{ module_vite('build-fina', 'resources/assets/sass/app.scss') }} --}}
+
+    </head>
+    <body>
+        @yield('content')
+
+        {{-- Laravel Vite - JS File --}}
+        {{-- {{ module_vite('build-fina', 'resources/assets/js/app.js') }} --}}
+    </body>
+</html>

--- a/modules/Fina/resources/views/product-cost-controlling/index.blade.php
+++ b/modules/Fina/resources/views/product-cost-controlling/index.blade.php
@@ -1,0 +1,5 @@
+@extends('fina::layouts.master')
+
+@section('content')
+    <h1>Product Cost Controlling</h1>
+@endsection

--- a/modules/Fina/routes/api.php
+++ b/modules/Fina/routes/api.php
@@ -7,6 +7,12 @@ use Modules\Fina\FI\AA\Http\Controllers\AssetController;
 use Modules\Fina\FI\BL\Http\Controllers\BankMasterController;
 use Modules\Fina\FI\BL\Http\Controllers\BankAccountController;
 use Modules\Fina\FI\BL\Http\Controllers\BankStatementController;
+use Modules\Fina\PC\Http\Controllers\MaterialCostController;
+use Modules\Fina\PC\Http\Controllers\InventoryValuationController;
+use Modules\Fina\PC\Http\Controllers\CostObjectControllingController;
+use Modules\Fina\PC\Http\Controllers\MaterialCostController;
+use Modules\Fina\PC\Http\Controllers\InventoryValuationController;
+use Modules\Fina\PC\Http\Controllers\CostObjectControllingController;
 
 Route::prefix('fina')->group(function () {
     Route::prefix('gl')->group(function () {
@@ -44,5 +50,22 @@ Route::prefix('fina')->group(function () {
         Route::get('bank-statements/{id}', [BankStatementController::class, 'show']);
         Route::put('bank-statements/{id}', [BankStatementController::class, 'update']);
         Route::delete('bank-statements/{id}', [BankStatementController::class, 'destroy']);
+    });
+
+    Route::prefix('pc')->group(function () {
+        Route::post('material-costs', [MaterialCostController::class, 'store']);
+        Route::get('material-costs/{id}', [MaterialCostController::class, 'show']);
+        Route::put('material-costs/{id}', [MaterialCostController::class, 'update']);
+        Route::delete('material-costs/{id}', [MaterialCostController::class, 'destroy']);
+
+        Route::post('inventory-valuations', [InventoryValuationController::class, 'store']);
+        Route::get('inventory-valuations/{id}', [InventoryValuationController::class, 'show']);
+        Route::put('inventory-valuations/{id}', [InventoryValuationController::class, 'update']);
+        Route::delete('inventory-valuations/{id}', [InventoryValuationController::class, 'destroy']);
+
+        Route::post('cost-object-controlling', [CostObjectControllingController::class, 'store']);
+        Route::get('cost-object-controlling/{id}', [CostObjectControllingController::class, 'show']);
+        Route::put('cost-object-controlling/{id}', [CostObjectControllingController::class, 'update']);
+        Route::delete('cost-object-controlling/{id}', [CostObjectControllingController::class, 'destroy']);
     });
 });

--- a/modules/Fina/src/Core/Providers/FinaServiceProvider.php
+++ b/modules/Fina/src/Core/Providers/FinaServiceProvider.php
@@ -13,6 +13,15 @@ use Modules\Fina\FI\BL\Infrastructure\Persistence\EloquentBankStatementRepositor
 use Modules\Fina\FI\BL\Application\BankMasterService;
 use Modules\Fina\FI\BL\Application\BankAccountService;
 use Modules\Fina\FI\BL\Application\BankStatementService;
+use Modules\Fina\PC\Domain\Repositories\MaterialCostRepositoryInterface;
+use Modules\Fina\PC\Infrastructure\Persistence\EloquentMaterialCostRepository;
+use Modules\Fina\PC\Domain\Repositories\InventoryValuationRepositoryInterface;
+use Modules\Fina\PC\Infrastructure\Persistence\EloquentInventoryValuationRepository;
+use Modules\Fina\PC\Domain\Repositories\CostObjectControllingRepositoryInterface;
+use Modules\Fina\PC\Infrastructure\Persistence\EloquentCostObjectControllingRepository;
+use Modules\Fina\PC\Application\MaterialCostService;
+use Modules\Fina\PC\Application\InventoryValuationService;
+use Modules\Fina\PC\Application\CostObjectControllingService;
 
 class FinaServiceProvider extends ServiceProvider
 {
@@ -61,6 +70,22 @@ class FinaServiceProvider extends ServiceProvider
 
         $this->app->singleton(BankStatementService::class, function ($app) {
             return new BankStatementService($app->make(BankStatementRepositoryInterface::class));
+        });
+
+        $this->app->bind(MaterialCostRepositoryInterface::class, EloquentMaterialCostRepository::class);
+        $this->app->bind(InventoryValuationRepositoryInterface::class, EloquentInventoryValuationRepository::class);
+        $this->app->bind(CostObjectControllingRepositoryInterface::class, EloquentCostObjectControllingRepository::class);
+
+        $this->app->singleton(MaterialCostService::class, function ($app) {
+            return new MaterialCostService($app->make(MaterialCostRepositoryInterface::class));
+        });
+
+        $this->app->singleton(InventoryValuationService::class, function ($app) {
+            return new InventoryValuationService($app->make(InventoryValuationRepositoryInterface::class));
+        });
+
+        $this->app->singleton(CostObjectControllingService::class, function ($app) {
+            return new CostObjectControllingService($app->make(CostObjectControllingRepositoryInterface::class));
         });
     }
 

--- a/modules/Fina/src/PC/Application/CostObjectControllingService.php
+++ b/modules/Fina/src/PC/Application/CostObjectControllingService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modules\Fina\PC\Application;
+
+use Modules\Fina\PC\Domain\Repositories\CostObjectControllingRepositoryInterface;
+
+class CostObjectControllingService
+{
+    private $costObjectControllingRepository;
+
+    public function __construct(CostObjectControllingRepositoryInterface $costObjectControllingRepository)
+    {
+        $this->costObjectControllingRepository = $costObjectControllingRepository;
+    }
+
+    public function createCostObjectControlling(array $data)
+    {
+        return $this->costObjectControllingRepository->create($data);
+    }
+
+    public function getCostObjectControlling(int $id)
+    {
+        return $this->costObjectControllingRepository->find($id);
+    }
+
+    public function updateCostObjectControlling(int $id, array $data)
+    {
+        return $this->costObjectControllingRepository->update($id, $data);
+    }
+
+    public function deleteCostObjectControlling(int $id)
+    {
+        return $this->costObjectControllingRepository->delete($id);
+    }
+}

--- a/modules/Fina/src/PC/Application/InventoryValuationService.php
+++ b/modules/Fina/src/PC/Application/InventoryValuationService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modules\Fina\PC\Application;
+
+use Modules\Fina\PC\Domain\Repositories\InventoryValuationRepositoryInterface;
+
+class InventoryValuationService
+{
+    private $inventoryValuationRepository;
+
+    public function __construct(InventoryValuationRepositoryInterface $inventoryValuationRepository)
+    {
+        $this->inventoryValuationRepository = $inventoryValuationRepository;
+    }
+
+    public function createInventoryValuation(array $data)
+    {
+        return $this->inventoryValuationRepository->create($data);
+    }
+
+    public function getInventoryValuation(int $id)
+    {
+        return $this->inventoryValuationRepository->find($id);
+    }
+
+    public function updateInventoryValuation(int $id, array $data)
+    {
+        return $this->inventoryValuationRepository->update($id, $data);
+    }
+
+    public function deleteInventoryValuation(int $id)
+    {
+        return $this->inventoryValuationRepository->delete($id);
+    }
+}

--- a/modules/Fina/src/PC/Application/MaterialCostService.php
+++ b/modules/Fina/src/PC/Application/MaterialCostService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Modules\Fina\PC\Application;
+
+use Modules\Fina\PC\Domain\Repositories\MaterialCostRepositoryInterface;
+
+class MaterialCostService
+{
+    private $materialCostRepository;
+
+    public function __construct(MaterialCostRepositoryInterface $materialCostRepository)
+    {
+        $this->materialCostRepository = $materialCostRepository;
+    }
+
+    public function createMaterialCost(array $data)
+    {
+        return $this->materialCostRepository->create($data);
+    }
+
+    public function getMaterialCost(int $id)
+    {
+        return $this->materialCostRepository->find($id);
+    }
+
+    public function updateMaterialCost(int $id, array $data)
+    {
+        return $this->materialCostRepository->update($id, $data);
+    }
+
+    public function deleteMaterialCost(int $id)
+    {
+        return $this->materialCostRepository->delete($id);
+    }
+}

--- a/modules/Fina/src/PC/Domain/Entities/CostObjectControlling.php
+++ b/modules/Fina/src/PC/Domain/Entities/CostObjectControlling.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Modules\Fina\PC\Domain\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CostObjectControlling extends Model
+{
+    protected $table = 'fina_pc_cost_object_controlling';
+
+    protected $fillable = [
+        'cost_object',
+        'cost_object_type',
+        'planned_costs',
+        'actual_costs',
+        'variance',
+        'currency',
+    ];
+}

--- a/modules/Fina/src/PC/Domain/Entities/InventoryValuation.php
+++ b/modules/Fina/src/PC/Domain/Entities/InventoryValuation.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Modules\Fina\PC\Domain\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+class InventoryValuation extends Model
+{
+    protected $table = 'fina_pc_inventory_valuations';
+
+    protected $fillable = [
+        'material_id',
+        'plant_id',
+        'quantity',
+        'value',
+        'currency',
+    ];
+}

--- a/modules/Fina/src/PC/Domain/Entities/MaterialCost.php
+++ b/modules/Fina/src/PC/Domain/Entities/MaterialCost.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\Fina\PC\Domain\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MaterialCost extends Model
+{
+    protected $table = 'fina_pc_material_costs';
+
+    protected $fillable = [
+        'material_id',
+        'costing_variant',
+        'cost',
+        'currency',
+    ];
+}

--- a/modules/Fina/src/PC/Domain/Repositories/CostObjectControllingRepositoryInterface.php
+++ b/modules/Fina/src/PC/Domain/Repositories/CostObjectControllingRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Fina\PC\Domain\Repositories;
+
+use Modules\Fina\PC\Domain\Entities\CostObjectControlling;
+
+interface CostObjectControllingRepositoryInterface
+{
+    public function create(array $data): CostObjectControlling;
+    public function find(int $id): ?CostObjectControlling;
+    public function update(int $id, array $data): bool;
+    public function delete(int $id): bool;
+}

--- a/modules/Fina/src/PC/Domain/Repositories/InventoryValuationRepositoryInterface.php
+++ b/modules/Fina/src/PC/Domain/Repositories/InventoryValuationRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Fina\PC\Domain\Repositories;
+
+use Modules\Fina\PC\Domain\Entities\InventoryValuation;
+
+interface InventoryValuationRepositoryInterface
+{
+    public function create(array $data): InventoryValuation;
+    public function find(int $id): ?InventoryValuation;
+    public function update(int $id, array $data): bool;
+    public function delete(int $id): bool;
+}

--- a/modules/Fina/src/PC/Domain/Repositories/MaterialCostRepositoryInterface.php
+++ b/modules/Fina/src/PC/Domain/Repositories/MaterialCostRepositoryInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Modules\Fina\PC\Domain\Repositories;
+
+use Modules\Fina\PC\Domain\Entities\MaterialCost;
+
+interface MaterialCostRepositoryInterface
+{
+    public function create(array $data): MaterialCost;
+    public function find(int $id): ?MaterialCost;
+    public function update(int $id, array $data): bool;
+    public function delete(int $id): bool;
+}

--- a/modules/Fina/src/PC/Http/Controllers/CostObjectControllingController.php
+++ b/modules/Fina/src/PC/Http/Controllers/CostObjectControllingController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Fina\PC\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\Fina\PC\Application\CostObjectControllingService;
+
+class CostObjectControllingController extends Controller
+{
+    private $costObjectControllingService;
+
+    public function __construct(CostObjectControllingService $costObjectControllingService)
+    {
+        $this->costObjectControllingService = $costObjectControllingService;
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->all();
+        $costObjectControlling = $this->costObjectControllingService->createCostObjectControlling($data);
+        return response()->json($costObjectControlling, 201);
+    }
+
+    public function show(int $id)
+    {
+        $costObjectControlling = $this->costObjectControllingService->getCostObjectControlling($id);
+        if (!$costObjectControlling) {
+            return response()->json(['message' => 'Cost object controlling not found'], 404);
+        }
+        return response()->json($costObjectControlling);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $data = $request->all();
+        $result = $this->costObjectControllingService->updateCostObjectControlling($id, $data);
+        return response()->json(['success' => $result]);
+    }
+
+    public function destroy(int $id)
+    {
+        $result = $this->costObjectControllingService->deleteCostObjectControlling($id);
+        return response()->json(['success' => $result]);
+    }
+}

--- a/modules/Fina/src/PC/Http/Controllers/InventoryValuationController.php
+++ b/modules/Fina/src/PC/Http/Controllers/InventoryValuationController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Fina\PC\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\Fina\PC\Application\InventoryValuationService;
+
+class InventoryValuationController extends Controller
+{
+    private $inventoryValuationService;
+
+    public function __construct(InventoryValuationService $inventoryValuationService)
+    {
+        $this->inventoryValuationService = $inventoryValuationService;
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->all();
+        $inventoryValuation = $this->inventoryValuationService->createInventoryValuation($data);
+        return response()->json($inventoryValuation, 201);
+    }
+
+    public function show(int $id)
+    {
+        $inventoryValuation = $this->inventoryValuationService->getInventoryValuation($id);
+        if (!$inventoryValuation) {
+            return response()->json(['message' => 'Inventory valuation not found'], 404);
+        }
+        return response()->json($inventoryValuation);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $data = $request->all();
+        $result = $this->inventoryValuationService->updateInventoryValuation($id, $data);
+        return response()->json(['success' => $result]);
+    }
+
+    public function destroy(int $id)
+    {
+        $result = $this->inventoryValuationService->deleteInventoryValuation($id);
+        return response()->json(['success' => $result]);
+    }
+}

--- a/modules/Fina/src/PC/Http/Controllers/MaterialCostController.php
+++ b/modules/Fina/src/PC/Http/Controllers/MaterialCostController.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Modules\Fina\PC\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Modules\Fina\PC\Application\MaterialCostService;
+
+class MaterialCostController extends Controller
+{
+    private $materialCostService;
+
+    public function __construct(MaterialCostService $materialCostService)
+    {
+        $this->materialCostService = $materialCostService;
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->all();
+        $materialCost = $this->materialCostService->createMaterialCost($data);
+        return response()->json($materialCost, 201);
+    }
+
+    public function show(int $id)
+    {
+        $materialCost = $this->materialCostService->getMaterialCost($id);
+        if (!$materialCost) {
+            return response()->json(['message' => 'Material cost not found'], 404);
+        }
+        return response()->json($materialCost);
+    }
+
+    public function update(Request $request, int $id)
+    {
+        $data = $request->all();
+        $result = $this->materialCostService->updateMaterialCost($id, $data);
+        return response()->json(['success' => $result]);
+    }
+
+    public function destroy(int $id)
+    {
+        $result = $this->materialCostService->deleteMaterialCost($id);
+        return response()->json(['success' => $result]);
+    }
+}

--- a/modules/Fina/src/PC/Infrastructure/Persistence/EloquentCostObjectControllingRepository.php
+++ b/modules/Fina/src/PC/Infrastructure/Persistence/EloquentCostObjectControllingRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Fina\PC\Infrastructure\Persistence;
+
+use Modules\Fina\PC\Domain\Entities\CostObjectControlling;
+use Modules\Fina\PC\Domain\Repositories\CostObjectControllingRepositoryInterface;
+
+class EloquentCostObjectControllingRepository implements CostObjectControllingRepositoryInterface
+{
+    public function create(array $data): CostObjectControlling
+    {
+        return CostObjectControlling::create($data);
+    }
+
+    public function find(int $id): ?CostObjectControlling
+    {
+        return CostObjectControlling::find($id);
+    }
+
+    public function update(int $id, array $data): bool
+    {
+        return CostObjectControlling::find($id)->update($data);
+    }
+
+    public function delete(int $id): bool
+    {
+        return CostObjectControlling::find($id)->delete();
+    }
+}

--- a/modules/Fina/src/PC/Infrastructure/Persistence/EloquentInventoryValuationRepository.php
+++ b/modules/Fina/src/PC/Infrastructure/Persistence/EloquentInventoryValuationRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Fina\PC\Infrastructure\Persistence;
+
+use Modules\Fina\PC\Domain\Entities\InventoryValuation;
+use Modules\Fina\PC\Domain\Repositories\InventoryValuationRepositoryInterface;
+
+class EloquentInventoryValuationRepository implements InventoryValuationRepositoryInterface
+{
+    public function create(array $data): InventoryValuation
+    {
+        return InventoryValuation::create($data);
+    }
+
+    public function find(int $id): ?InventoryValuation
+    {
+        return InventoryValuation::find($id);
+    }
+
+    public function update(int $id, array $data): bool
+    {
+        return InventoryValuation::find($id)->update($data);
+    }
+
+    public function delete(int $id): bool
+    {
+        return InventoryValuation::find($id)->delete();
+    }
+}

--- a/modules/Fina/src/PC/Infrastructure/Persistence/EloquentMaterialCostRepository.php
+++ b/modules/Fina/src/PC/Infrastructure/Persistence/EloquentMaterialCostRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Modules\Fina\PC\Infrastructure\Persistence;
+
+use Modules\Fina\PC\Domain\Entities\MaterialCost;
+use Modules\Fina\PC\Domain\Repositories\MaterialCostRepositoryInterface;
+
+class EloquentMaterialCostRepository implements MaterialCostRepositoryInterface
+{
+    public function create(array $data): MaterialCost
+    {
+        return MaterialCost::create($data);
+    }
+
+    public function find(int $id): ?MaterialCost
+    {
+        return MaterialCost::find($id);
+    }
+
+    public function update(int $id, array $data): bool
+    {
+        return MaterialCost::find($id)->update($data);
+    }
+
+    public function delete(int $id): bool
+    {
+        return MaterialCost::find($id)->delete();
+    }
+}

--- a/modules/Fina/tests/Feature/PCSubdomainTest.php
+++ b/modules/Fina/tests/Feature/PCSubdomainTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Modules\Fina\Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Modules\Fina\Tests\TestCase;
+
+class PCSubdomainTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_material_cost()
+    {
+        $response = $this->postJson('/api/fina/pc/material-costs', [
+            'material_id' => 1,
+            'costing_variant' => 'test',
+            'cost' => 100,
+            'currency' => 'USD',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_create_inventory_valuation()
+    {
+        $response = $this->postJson('/api/fina/pc/inventory-valuations', [
+            'material_id' => 1,
+            'plant_id' => 1,
+            'quantity' => 10,
+            'value' => 1000,
+            'currency' => 'USD',
+        ]);
+
+        $response->assertStatus(201);
+    }
+
+    public function test_create_cost_object_controlling()
+    {
+        $response = $this->postJson('/api/fina/pc/cost-object-controlling', [
+            'cost_object' => 'test',
+            'cost_object_type' => 'test',
+            'planned_costs' => 1000,
+            'actual_costs' => 1200,
+            'variance' => 200,
+            'currency' => 'USD',
+        ]);
+
+        $response->assertStatus(201);
+    }
+}


### PR DESCRIPTION
This commit implements the Product Cost Controlling (PC) subdomain in the Fina module.

It includes the following changes:
-   Created migrations for material costing, inventory valuation, and cost object controlling.
-   Created models, repositories, and services for product cost controlling.
-   Created controllers and API routes for product cost controlling.
-   Registered the new services and repositories in the FinaServiceProvider.
-   Added a basic feature test for the new API endpoints.

However, I was unable to get the tests to run. I faced several issues with the environment and the tooling, and I was unable to resolve them.

The main issue is that the `php artisan test` command is not able to find the test file, even when the full path is provided.

I am submitting my work in its current state, as I am unable to proceed further.